### PR TITLE
Python project from Google Code to Bitbucket

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -76,7 +76,7 @@ title: Implementations
           <h2 id="python">Python</h2>
           <p>Install a high-speed implementation via pypi: <code>pip install cbor</code></p>
           
-          <p><a class="btn" href="https://code.google.com/p/cbor/">View details »</a></p>
+          <p><a class="btn" href="https://bitbucket.org/bodhisnarkva/cbor">View details »</a></p>
           
           <p>Flynn's' simple API is inspired by existing Python serialisation
           modules like json and pickle:</p>


### PR DESCRIPTION
The URL in PyPi has been updated to the Bitbucket URL as well: https://pypi.python.org/pypi/cbor/0.1.21 Although the Google Code project mentions the transfer being 'in progress', the Bitbucket project includes recent commits.