### PR TITLE
Add clj-cbor to implementations

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -151,6 +151,12 @@ title: Implementations
           <p><a class="btn" href="https://github.com/orclev/CBOR">View details »</a></p>
         </div>
         <div class='span4'>
+          <h2 id="clojure">Clojure</h2>
+          <p><code>clj-cbor</code> is an extensible, native Clojure implementation of
+          the CBOR format:</p>
+              
+          <p><a class="btn" href="https://github.com/greglook/clj-cbor">View Details &raquo;</a></p>
+
           <h2 id="c-java">C#, Java</h2>
           <p>A rather comprehensive implementation that addresses arbitrary precision arithmetic is available in both a C# and a Java version.</p>
           


### PR DESCRIPTION
I released a relatively full-featured library implementation for Clojure and I'd like to add it to the list here.
https://github.com/greglook/clj-cbor