### PR TITLE
Add serde based cbor link for rust

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -64,6 +64,11 @@ title: Implementations
           <a href="https://crates.io/crates/cbor-codec">crates.io</a>:</p>
           
           <p><a class="btn" href="https://github.com/twittner/cbor-codec">View details &raquo;</a></p>
+
+          <p>An implementation using Serde, a framework for serializing and deserializing Rust data structures efficiently and generically, is in the works and available on
+          <a href="https://crates.io/crates/serde_cbor">crates.io</a>:</p>
+
+          <p><a class="btn" href="https://github.com/pyfisch/cbor">View details &raquo;</a></p>
           
           <h2 id="swift">Swift</h2>
           


### PR DESCRIPTION
I came across a Serde based implementation of CBOR which, based on crates.io activity, seems to be getting the majority of use these days. 