### PR TITLE
Add links to browser and nodejs implementations

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -21,7 +21,7 @@ title: Implementations
       <div class='row-fluid'>
         <div class='span4'>
           <h2 id="javascript">JavaScript</h2>
-          <p>JavaScript implementations are available both for in-browser use and for node.js.</p>
+          <p>JavaScript implementations are available both for in-<a href="#browser">browser</a> use and for <a href="#nodejs">node.js.</a></p>
           
           <h3 id="browser">Browser</h3>
           <p>A CBOR object can be installed via <code>bower install cbor</code> and used as an AMD module or global object in the browser e.g. in combination with Websockets&#8230;</p>


### PR DESCRIPTION
I did not realize that I needed to read past further headings in the JavaScript section to find implementation details.  This add links to save other users the same confusion.