### PR TITLE
Fix links to moved Go and Python implementations

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -64,7 +64,7 @@ title: Implementations
           
           <p>Another, more full-grown Go implementation:</p>
           
-          <p><a class="btn" href="https://bitbucket.org/bodhisnarkva/cbor">View details &raquo;</a></p>
+          <p><a class="btn" href="https://github.com/brianolson/cbor_go">View details &raquo;</a></p>
           
           <p>Most recently, a comprehensive, high-performance implementation has become available as part of a larger set of data representation format en- and decoders:</p>
           
@@ -126,7 +126,7 @@ title: Implementations
           <h2 id="python">Python</h2>
           <p>Install a high-speed implementation via pypi: <code>pip install cbor</code> (and/or possibly <code>pip3 install cbor</code>)</p>
           
-          <p><a class="btn" href="https://bitbucket.org/bodhisnarkva/cbor">View details »</a></p>
+          <p><a class="btn" href="https://github.com/brianolson/cbor_py">View details »</a></p>
           
           <p>Flynn's' simple API is inspired by existing Python serialisation
           modules like json and pickle:</p>


### PR DESCRIPTION
The projects under bitbucket/bodhisnarkva have moved to github/brianolson