### PR TITLE
Add link to cbor-diag Rust diagnostics implementation

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -112,6 +112,12 @@ title: Implementations
           
           <p><a class="btn" href="https://github.com/pyfisch/cbor">View details &raquo;</a></p>
           
+          <p><a href="https://crates.io/crates/cbor-diag"><code>cbor-diag</code></a>
+          is another parser targeted specifically at generating diagnostic
+          notation and annotated hex for debugging</p>
+          
+          <p><a class="btn" href="https://github.com/Nemo157/cbor-diag-rs">View details &raquo;</a></p>
+          
           <h2 id="swift">Swift</h2>
           
           <p>A Swift implementation without a Foundation dependency (cross-platform ready):</p>


### PR DESCRIPTION
I've been working on this for a while and finally got it to a state where it's got pretty complete coverage.

This is powering my alternative playground https://cbor.nemo157.com and CLI tool https://crates.io/crates/cbor-diag-cli.