### PR TITLE
Update impls.html

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -80,7 +80,7 @@ title: Implementations
           
           <h2 id="go">Go</h2>
           
-          <p>A fast Go implementation that feels like the JSON library:</p>
+          <p>The newest Go implementation is fast, safe, and full-featured with API like JSON + toarray/keyasint struct tags:</p>
           
           <p><a class="btn" href="https://github.com/fxamacker/cbor">View details &raquo;</a></p>
           
@@ -88,7 +88,7 @@ title: Implementations
           
           <p><a class="btn" href="https://github.com/brianolson/cbor_go">View details &raquo;</a></p>
           
-          <p>Most recently, a comprehensive, high-performance implementation has become available as part of a larger set of data representation format en- and decoders:</p>
+          <p>A comprehensive, high-performance implementation as part of a larger set of data representation format en- and decoders:</p>
           
           <p><a class="btn" href="https://godoc.org/github.com/ugorji/go/codec#CborHandle">View details &raquo;</a></p>
           


### PR DESCRIPTION
Removed "Most recently," from an old library under Go impls.  
Added short description of fxamacker/cbor beginning with "The newest Go implementation".

I used "full-featured" because fxamacker/cbor is the only Go impl on the list that supports preferred serialization and detection of duplicate map keys.

@cabo Thank you for adding my library to cbor.io!