### PR TITLE
Add crystal implementation

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -252,7 +252,7 @@ title: Implementations
               
           <h2 id="crystal">Crystal</h2>
           
-          <p>Encoding and decoding library with a simple API inspired by the Crystal sdtlib JSON package:</p>
+          <p>Encoding and decoding library with a simple API inspired by the Crystal stdlib JSON package:</p>
           
           <p><a class="btn" href="https://sr.ht/~arestifo/crystal-cbor/">View Details »</a></p>
         </div>

--- a/impls.html
+++ b/impls.html
@@ -249,6 +249,12 @@ title: Implementations
           <p>A compact D implementation with a <a href="https://code.dlang.org/packages/cbor-d">Dub package</a>:</p>
           
           <p><a class="btn" href="https://github.com/MrSmith33/cbor-d">View Details »</a></p>
+              
+          <h2 id="crystal">Crystal</h2>
+          
+          <p>Encoding and decoding library with a simple API inspired by the Crystal sdtlib JSON package:</p>
+          
+          <p><a class="btn" href="https://sr.ht/~arestifo/crystal-cbor/">View Details »</a></p>
         </div>
         <div class='span4'>
           <h2 id="java">Java</h2>


### PR DESCRIPTION
I just published the first version of my Crystal implementation of the CBOR protocol: https://sr.ht/~arestifo/crystal-cbor/

This MR adds a link to it in the "implementations" page.