### PR TITLE
Remove link to python 'cbor' package

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -179,10 +179,6 @@ title: Implementations
           
           <p><a class="btn" href="https://pypi.io/project/cbor2/">View details »</a></p>
           
-          <p>Install a high-speed implementation via pypi: <code>pip install cbor</code> (and/or possibly <code>pip3 install cbor</code>)</p>
-          
-          <p><a class="btn" href="https://github.com/brianolson/cbor_py">View details »</a></p>
-          
           <p>Flynn's' simple API is inspired by existing Python serialisation
           modules like json and pickle:</p>
           


### PR DESCRIPTION
This package has not been released in 6 years: https://pypi.org/project/cbor/#history . The github page for it lists only testing for now unsupported python versions: https://github.com/brianolson/cbor_py

In contrast the cbor2 package, mentioned previously, is well maintained, and also performant since it's written in C.