### PR TITLE
Add zcbor to impls.html

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -393,5 +393,8 @@ title: Implementations
           code size, a test suite and documentation.</p>
           
           <p><a class="btn" href="https://github.com/laurencelundblade/QCBOR">View details »</a></p>
+
+          <p>zcbor is a low footprint C/C++ CBOR library and Python tool providing code generation from CDDL descriptions.</p>
+          <p><a class="btn" href="https://github.com/NordicSemiconductor/zcbor">View details »</a></p>
         </div>
       </div>


### PR DESCRIPTION
Fixes #97 and #78 (cddl-gen was renamed to zcbor)