### PR TITLE
Add cbor2 to implementation list

### DIFF
--- a/impls.html
+++ b/impls.html
@@ -116,8 +116,8 @@ title: Implementations
           for Rust, available on
           <a href="https://crates.io/crates/cbor2">crates.io</a>. It supports:
           async item I/O, serde round trips, canonical and deterministic encoding,
-          Value/RawValue, semantic tags, COSE integer keys and arrays,
-          validation, diagnostic notation, and no_std.</p>
+          Value/RawValue, COSE-style integer map keys, semantic tags,
+          exact-one-item validation, diagnostic notation, and no_std.</p>
           
           <p><a class="btn" href="https://github.com/ldclabs/cbor2">View details &raquo;</a></p>
           

--- a/impls.html
+++ b/impls.html
@@ -117,7 +117,7 @@ title: Implementations
           <a href="https://crates.io/crates/cbor2">crates.io</a>. It supports:
           async item I/O, serde round trips, canonical and deterministic encoding,
           Value/RawValue, COSE-style integer map keys, semantic tags,
-          exact-one-item validation, diagnostic notation, and no_std.</p>
+          diagnostic notation, no_std, with separately available well-formedness check.</p>
           
           <p><a class="btn" href="https://github.com/ldclabs/cbor2">View details &raquo;</a></p>
           

--- a/impls.html
+++ b/impls.html
@@ -111,6 +111,12 @@ title: Implementations
           serde module has declined to add support:</p>
           
           <p><a class="btn" href="https://github.com/pyfisch/cbor">View details &raquo;</a></p>
+
+          <p>The cbor2 implementation, available on
+          <a href="https://crates.io/crates/cbor2">crates.io</a>, supports CBOR tags
+          and a no_std/no_alloc feature matrix:</p>
+          
+          <p><a class="btn" href="https://github.com/ldclabs/cbor2">View details &raquo;</a></p>
           
           <p>The CBOR-CODEC implementation, available on
           <a href="https://crates.io/crates/cbor-codec">crates.io</a>, supports Tags and can deal with objects without size limits:</p>

--- a/impls.html
+++ b/impls.html
@@ -112,9 +112,12 @@ title: Implementations
           
           <p><a class="btn" href="https://github.com/pyfisch/cbor">View details &raquo;</a></p>
 
-          <p>The cbor2 implementation, available on
-          <a href="https://crates.io/crates/cbor2">crates.io</a>, supports CBOR tags
-          and a no_std/no_alloc feature matrix:</p>
+          <p>The cbor2 implementation is a full-featured RFC 8949 implementation
+          for Rust, available on
+          <a href="https://crates.io/crates/cbor2">crates.io</a>. It supports:
+          async item I/O, serde round trips, canonical and deterministic encoding,
+          Value/RawValue, semantic tags, COSE integer keys and arrays,
+          validation, diagnostic notation, and no_std.</p>
           
           <p><a class="btn" href="https://github.com/ldclabs/cbor2">View details &raquo;</a></p>
           


### PR DESCRIPTION
Add cbor2 to the Rust implementations list on https://cbor.io/impls.html with links to crates.io and GitHub.